### PR TITLE
chore: fix CI caching of Go packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           path: |
             ~/Library/Caches/go-build
             ~/go/
-          key: ${{ runner.os }}-go-${{ github.head_ref }}
+          key: ${{ runner.os }}-go-${{ github.ref }}
           restore-keys: |
             ${{ runner.os }}-go-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           path: |
             ~/Library/Caches/go-build
             ~/go/
-          key: ${{ runner.os }}-go-${{ hashFiles('scripts/ci-go-deps.sh') }}
+          key: ${{ runner.os }}-go-${{ github.head_ref }}
           restore-keys: |
             ${{ runner.os }}-go-
 


### PR DESCRIPTION
Since the Go packages in `ci-go-deps.sh` are pinned to `@latest`, they won't ever change and the cache key will never update. Bind it to the `ref` of a PR so the latest versions of the CI dependencies are always installed, and subsequent commits on an open PR will take advantage of the caching.